### PR TITLE
Replace sudo-prompt with @vscode/sudo-prompt

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   },
   "dependencies": {
     "electron-updater": "^6.7.3",
-    "sudo-prompt": "^9.2.1"
+    "@vscode/sudo-prompt": "^9.3.1"
   },
   "build": {
     "appId": "com.sonic.unblockpro",


### PR DESCRIPTION
This PR replaces the deprecated sudo-prompt dependency with the actively maintained @vscode/sudo-prompt fork.

Why:

Deprecation: The original sudo-prompt package is no longer supported and its repository is archived.

Maintenance: @vscode/sudo-prompt is the official fork maintained by Microsoft, ensuring continued compatibility and security updates.

Reduced Warnings: This clears the npm warn deprecated messages that users see during installation.