### PR TITLE
feat: opt-out авто-апдейта (notify-only) — #29

### DIFF
--- a/src/main/main.js
+++ b/src/main/main.js
@@ -29,6 +29,7 @@ const {
 dns.setDefaultResultOrder('ipv4first');
 const ipv4Lookup = (host, opts, cb) => dns.lookup(host, { family: 4 }, cb);
 const { autoUpdater } = require('electron-updater');
+const { resolveUpdateMode } = require('./update-mode');
 
 let mainWindow;
 let tray;
@@ -56,7 +57,7 @@ function loadSettings() {
       return JSON.parse(fs.readFileSync(settingsPath, 'utf8'));
     }
   } catch (e) {}
-  return { autoStart: false, autoConnect: false, selectedStrategy: 'auto', lastWorkingStrategy: null };
+  return { autoStart: false, autoConnect: false, selectedStrategy: 'auto', lastWorkingStrategy: null, autoUpdate: true };
 }
 
 function saveSettings(settings) {
@@ -2641,7 +2642,8 @@ function createTray() {
 function setupAutoUpdater() {
   if (isDev) return; // Don't check for updates in dev mode
   
-  const manualInstall = process.platform === 'darwin';
+  const settings = loadSettings();
+  const { manualInstall } = resolveUpdateMode({ platform: process.platform, autoUpdate: settings.autoUpdate });
   autoUpdater.autoDownload = !manualInstall;
   autoUpdater.autoInstallOnAppQuit = !manualInstall;
   
@@ -2957,7 +2959,9 @@ ipcMain.handle('install-update', async () => {
     return { ok: false, error: 'В режиме разработки обновление недоступно' };
   }
 
-  if (process.platform === 'darwin') {
+  const updateSettings = loadSettings();
+  const { manualInstall } = resolveUpdateMode({ platform: process.platform, autoUpdate: updateSettings.autoUpdate });
+  if (manualInstall) {
     return {
       ok: false,
       manual: true,
@@ -3012,6 +3016,13 @@ ipcMain.handle('set-auto-start', (event, enabled) => {
 ipcMain.handle('set-auto-connect', (event, enabled) => {
   const settings = loadSettings();
   settings.autoConnect = enabled;
+  saveSettings(settings);
+  return { success: true };
+});
+
+ipcMain.handle('set-auto-update', (event, enabled) => {
+  const settings = loadSettings();
+  settings.autoUpdate = enabled;
   saveSettings(settings);
   return { success: true };
 });

--- a/src/main/preload.js
+++ b/src/main/preload.js
@@ -28,6 +28,7 @@ contextBridge.exposeInMainWorld('api', {
   // Updates
   installUpdate: () => ipcRenderer.invoke('install-update'),
   checkForUpdates: () => ipcRenderer.invoke('check-for-updates'),
+  setAutoUpdate: (enabled) => ipcRenderer.invoke('set-auto-update', enabled),
   
   // Logs & errors
   getLogs: () => ipcRenderer.invoke('get-logs'),

--- a/src/main/update-mode.js
+++ b/src/main/update-mode.js
@@ -1,0 +1,11 @@
+'use strict';
+
+// Decides whether updates must be installed manually (notify-only) vs automatically.
+// macOS is always manual (unsigned app can't self-replace). On other platforms the
+// user opts out via the autoUpdate setting; only an explicit `false` means manual.
+function resolveUpdateMode({ platform, autoUpdate } = {}) {
+  const manualInstall = platform === 'darwin' || autoUpdate === false;
+  return { manualInstall };
+}
+
+module.exports = { resolveUpdateMode };

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -192,6 +192,16 @@
             <span class="toggle-slider"></span>
           </label>
         </div>
+        <div class="setting-row">
+          <div class="setting-info">
+            <span class="setting-label">Обновлять автоматически</span>
+            <span class="setting-desc">Выкл — только уведомлять, ставить вручную</span>
+          </div>
+          <label class="toggle">
+            <input type="checkbox" id="autoupdateToggle">
+            <span class="toggle-slider"></span>
+          </label>
+        </div>
       </div>
 
       <!-- Custom domains -->

--- a/src/renderer/renderer.js
+++ b/src/renderer/renderer.js
@@ -13,6 +13,7 @@ const progressFill = document.getElementById('progressFill');
 const downloadPercent = document.getElementById('downloadPercent');
 const autostartToggle = document.getElementById('autostartToggle');
 const autoconnectToggle = document.getElementById('autoconnectToggle');
+const autoupdateToggle = document.getElementById('autoupdateToggle');
 const strategySelect = document.getElementById('strategySelect');
 
 // New UI elements
@@ -123,6 +124,10 @@ function setupEventListeners() {
   
   autoconnectToggle.addEventListener('change', async () => {
     await window.api.setAutoConnect(autoconnectToggle.checked);
+  });
+
+  autoupdateToggle.addEventListener('change', async () => {
+    await window.api.setAutoUpdate(autoupdateToggle.checked);
   });
   
   // Strategy selector
@@ -237,6 +242,7 @@ async function loadSettings() {
     const settings = await window.api.getSettings();
     autostartToggle.checked = settings.autoStart || false;
     autoconnectToggle.checked = settings.autoConnect || false;
+    autoupdateToggle.checked = settings.autoUpdate !== false;
     
     // Set strategy selector
     if (settings.selectedStrategy && settings.selectedStrategy !== 'auto') {

--- a/test/update-mode.test.js
+++ b/test/update-mode.test.js
@@ -1,0 +1,20 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const test = require('node:test');
+
+const { resolveUpdateMode } = require('../src/main/update-mode');
+
+test('macOS always installs manually regardless of the autoUpdate setting', () => {
+  assert.equal(resolveUpdateMode({ platform: 'darwin', autoUpdate: true }).manualInstall, true);
+  assert.equal(resolveUpdateMode({ platform: 'darwin', autoUpdate: false }).manualInstall, true);
+});
+
+test('other platforms auto-install unless the user opts out', () => {
+  assert.equal(resolveUpdateMode({ platform: 'win32', autoUpdate: true }).manualInstall, false);
+  assert.equal(resolveUpdateMode({ platform: 'win32', autoUpdate: false }).manualInstall, true);
+});
+
+test('a missing autoUpdate setting keeps automatic installs on non-macOS platforms', () => {
+  assert.equal(resolveUpdateMode({ platform: 'win32', autoUpdate: undefined }).manualInstall, false);
+});


### PR DESCRIPTION
## Что
Настройка «Обновлять автоматически» (по умолчанию вкл). Если выключить — приложение по-прежнему проверяет обновления и показывает «доступно vX», но не качает и не ставит само (тот же ручной путь, что уже у macOS). Closes #29.

## Изменения
- `src/main/update-mode.js` — чистая `resolveUpdateMode({platform, autoUpdate}) → {manualInstall}` + юнит-тесты
- `src/main/main.js` — дефолт `autoUpdate: true`; `setupAutoUpdater` и `install-update` через `resolveUpdateMode`; новый IPC `set-auto-update`
- `src/main/preload.js` — `setAutoUpdate`
- `src/renderer/index.html` + `renderer.js` — тумблер настройки

## Как проверить
- `npm test` (включая `test/update-mode.test.js`) — зелёный
- Windows: тумблер выкл → «доступно vX» без авто-установки, «обновить» ведёт на страницу релиза; тумблер вкл (дефолт) → прежнее авто-поведение
- macOS: поведение не меняется

🤖 Generated with [Claude Code](https://claude.com/claude-code)
