### PR TITLE
chore: формы иссью с обязательными ОС, версией, провайдером и журналом

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,94 @@
+name: Проблема в работе
+description: Обход не работает, ошибка при подключении, что-то сломалось
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Спасибо за репорт. Заполните поля ниже — без них проблему почти невозможно
+        воспроизвести: одна и та же ошибка на разных провайдерах имеет разные причины.
+
+  - type: input
+    id: app-version
+    attributes:
+      label: Версия UnblockPro
+      description: Видно в заголовке окна приложения. Проверьте на последней версии перед репортом.
+      placeholder: "2.0.20"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: os
+    attributes:
+      label: Операционная система
+      options:
+        - macOS (Apple Silicon — M1/M2/M3/M4)
+        - macOS (Intel)
+        - Windows 11
+        - Windows 10
+        - Другое
+    validations:
+      required: true
+
+  - type: input
+    id: os-version
+    attributes:
+      label: Версия ОС
+      placeholder: "macOS Sequoia 15.7.7 / Windows 11 23H2"
+    validations:
+      required: true
+
+  - type: input
+    id: isp
+    attributes:
+      label: Провайдер и город
+      description: Блокировки различаются по провайдерам — без этого поля репорт почти бесполезен.
+      placeholder: "МГТС, Москва"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: broken
+    attributes:
+      label: Что именно не работает
+      multiple: true
+      options:
+        - YouTube — страница не открывается
+        - YouTube — интерфейс открывается, видео не грузится
+        - Discord — не открывается вообще
+        - Discord — вечное «подключение» к голосовому каналу
+        - Приложение не подключается («ни одна стратегия не сработала»)
+        - Ошибка при скачивании бинарников
+        - Другое
+    validations:
+      required: true
+
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: Что происходит
+      description: Что вы сделали, что ожидали и что получили. Скриншот ошибки приложите сюда же.
+    validations:
+      required: true
+
+  - type: textarea
+    id: log
+    attributes:
+      label: Журнал
+      description: |
+        В главном окне разверните карточку «Журнал» и нажмите «Скопировать журнал»,
+        затем вставьте содержимое сюда. Если кнопки нет — у вас версия старше 2.0.21,
+        приложите скриншот развёрнутого журнала.
+      render: text
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Перед отправкой
+      options:
+        - label: Проверил на последней версии из Releases
+          required: true
+        - label: Попробовал отключиться и подключиться заново, чтобы перебор стратегий прошёл заново
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Последний релиз
+    url: https://github.com/by-sonic/unblock-pro/releases/latest
+    about: Прежде чем сообщать о проблеме, проверьте её на последней версии.
+  - name: FAQ
+    url: https://github.com/by-sonic/unblock-pro#faq
+    about: Частые вопросы — свои домены, установка, требования к системе.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,26 @@
+name: Предложение
+description: Идея или пожелание к приложению
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Какую задачу это решает
+      description: Опишите ситуацию, в которой вам не хватает текущих возможностей.
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Как это могло бы работать
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Чем пользуетесь сейчас
+      description: Обходные пути или другие приложения, которые закрывают эту задачу.
+    validations:
+      required: false


### PR DESCRIPTION
Закрывает организационную дыру, из-за которой репорты нельзя воспроизвести.

Сейчас в `.github` только `workflows/build.yml` — шаблонов нет вообще, и каждый репорт приходит без части данных: в #56 нет версии приложения, в #58 нет журнала, в #46 не указана ОС.

## Что в PR

- `bug_report.yml` — обязательные поля: версия приложения, ОС и её версия, **провайдер и город**, что именно не работает (список из реальных формулировок трекера), описание. Журнал — опциональное поле с инструкцией. Чекбоксы «проверил на последней версии» и «переподключился заново».
- `feature_request.yml` — задача, предложение, чем пользуется сейчас.
- `config.yml` — `blank_issues_enabled: false`, ссылки на Releases и FAQ.

Провайдер сделан обязательным намеренно: блокировки различаются по провайдерам, и без этого поля репорт «не работает» неотличим от десятка других.

## Проверка

Оба файла разбираются `js-yaml` без ошибок. Полей формы GitHub касается только при создании иссью — на сборку и релиз не влияет.

Поле «Журнал» ссылается на кнопку «Скопировать журнал», которой пока нет — она в отдельном PR. До его мержа текст просит скриншот.