### PR TITLE
feat: экспорт журнала + карточка журнала перестала схлопываться в 2px

### DIFF
--- a/src/main/log-report.js
+++ b/src/main/log-report.js
@@ -1,0 +1,108 @@
+'use strict';
+
+// Diagnostics the user can actually hand over.
+//
+// The in-app log used to be a 100-entry array in memory with no way out of the
+// window: no file, no copy button. Asking a reporter for "журнал" therefore
+// asked for something that did not exist — in #46 and #56 the answer was
+// literally "не понимаю, где его взять". Worse, one auto-select sweep walks 52
+// macOS strategies through 68 logging points, so the beginning of the run — the
+// part that says which probe rejected which strategy — was already evicted from
+// the ring buffer by the time the error appeared on screen.
+//
+// This module gives the log a file with a bounded size, and formats a report
+// that leads with the facts the issue form asks for (app version, OS, strategy)
+// so a paste into GitHub is self-contained.
+//
+// Logging must never be able to break the app: every filesystem failure here is
+// swallowed. A missing log is an inconvenience; a crashed connect flow is not.
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+// One megabyte of plain text is far more than one sweep produces, and small
+// enough to paste-quote or attach without thinking about it.
+const MAX_LOG_BYTES = 1024 * 1024;
+
+const ROTATED_SUFFIX = '.1';
+
+const SEPARATOR = '-'.repeat(52);
+
+function formatLogLine(entry = {}) {
+  const at = new Date(entry.timestamp || Date.now()).toISOString();
+  const level = entry.type || 'info';
+  // One entry stays one line: a multi-line message would otherwise be
+  // indistinguishable from separate events when read back.
+  const message = String(entry.message == null ? '' : entry.message).replace(/\r?\n/g, ' ⏎ ');
+  return `${at}  ${level}  ${message}`;
+}
+
+function rotate(filePath) {
+  const rotated = filePath + ROTATED_SUFFIX;
+  // renameSync onto an existing path fails on Windows, so clear the target
+  // first. Only one generation is kept — the previous sweep is the useful
+  // history, anything older is noise.
+  try { fs.rmSync(rotated, { force: true }); } catch (e) {}
+  fs.renameSync(filePath, rotated);
+}
+
+function appendLogLine(filePath, entry, { maxBytes = MAX_LOG_BYTES } = {}) {
+  try {
+    const line = formatLogLine(entry) + '\n';
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+
+    let size = 0;
+    try { size = fs.statSync(filePath).size; } catch (e) {}
+    if (size > 0 && size + Buffer.byteLength(line) > maxBytes) rotate(filePath);
+
+    fs.appendFileSync(filePath, line, 'utf8');
+  } catch (e) {
+    // Deliberately silent — see the header.
+  }
+}
+
+function readFileOrEmpty(filePath) {
+  try {
+    return fs.readFileSync(filePath, 'utf8');
+  } catch (e) {
+    return '';
+  }
+}
+
+// The rotated file plus the current one, oldest first, so a sweep that spanned a
+// rotation still reads as one history.
+function readLogTail(filePath) {
+  return readFileOrEmpty(filePath + ROTATED_SUFFIX) + readFileOrEmpty(filePath);
+}
+
+function buildLogReport({ fileText = '', entries = [], systemInfo = {}, generatedAt = Date.now() } = {}) {
+  const {
+    appVersion = 'неизвестно',
+    osName = 'неизвестно',
+    osVersion = '',
+    arch = '',
+    strategy = null
+  } = systemInfo;
+
+  const body = fileText.trim()
+    || entries.map(formatLogLine).join('\n').trim()
+    || 'Журнал пуст — приложение ещё ничего не записало.';
+
+  return [
+    `UnblockPro ${appVersion}`,
+    `${osName} ${osVersion} (${arch})`.replace(/\s+\(\)$/, ''),
+    `Стратегия: ${strategy || 'не подключена'}`,
+    `Сформировано: ${new Date(generatedAt).toISOString()}`,
+    SEPARATOR,
+    body,
+    ''
+  ].join('\n');
+}
+
+module.exports = {
+  MAX_LOG_BYTES,
+  appendLogLine,
+  buildLogReport,
+  formatLogLine,
+  readLogTail
+};

--- a/src/main/main.js
+++ b/src/main/main.js
@@ -1,10 +1,11 @@
-const { app, BrowserWindow, ipcMain, Tray, Menu, nativeImage, dialog } = require('electron');
+const { app, BrowserWindow, ipcMain, Tray, Menu, nativeImage, dialog, clipboard, shell } = require('electron');
 const path = require('path');
 const { spawn, exec, execFile, execFileSync, execSync } = require('child_process');
 const fs = require('fs');
 const https = require('https');
 const crypto = require('crypto');
 const dns = require('dns');
+const os = require('os');
 const tls = require('tls');
 const sudo = require('sudo-prompt');
 const { isMachOBinary, isMachOBinaryRunnable } = require('./binary-format');
@@ -16,6 +17,7 @@ const {
   replaceMarkedBlock
 } = require('./system-files');
 const { copyFileResilient } = require('./safe-copy');
+const { appendLogLine, buildLogReport, readLogTail } = require('./log-report');
 const {
   describeChildExit,
   hasExited,
@@ -1210,11 +1212,48 @@ function sendStatus(extra = {}) {
   }
 }
 
+// Where the log lives on disk. userData is writable without elevation on both
+// platforms and survives an app update.
+function getLogFilePath() {
+  return path.join(app.getPath('userData'), 'unblockpro.log');
+}
+
+// os.release() reports the Darwin kernel version on macOS ("24.6.0"), which is
+// not what a user or a bug report means by "версия macOS".
+function describeOsVersion() {
+  if (process.platform === 'darwin') {
+    try {
+      return execSync('sw_vers -productVersion', { encoding: 'utf8', stdio: 'pipe', timeout: 2000 }).trim();
+    } catch (e) {
+      return os.release();
+    }
+  }
+  return os.release();
+}
+
+function buildCurrentLogReport() {
+  const platformNames = { darwin: 'macOS', win32: 'Windows' };
+  return buildLogReport({
+    fileText: readLogTail(getLogFilePath()),
+    entries: logEntries,
+    systemInfo: {
+      appVersion: app.getVersion(),
+      osName: platformNames[process.platform] || process.platform,
+      osVersion: describeOsVersion(),
+      arch: process.arch,
+      strategy: currentStrategy
+    }
+  });
+}
+
 function sendLog(entry) {
   // entry: { type: 'info'|'success'|'error'|'warning', message: string, timestamp: number }
   console.log(`[${entry.type}] ${entry.message}`);
   const logEntry = { ...entry, timestamp: Date.now() };
   logEntries.push(logEntry);
+  // The window keeps a short tail; the file keeps the whole sweep, which is the
+  // only copy that outlives a restart and can be attached to an issue.
+  appendLogLine(getLogFilePath(), logEntry);
   // Keep only last 100 entries
   if (logEntries.length > 100) logEntries.shift();
   if (mainWindow && mainWindow.webContents) {
@@ -3043,6 +3082,34 @@ ipcMain.handle('get-status', () => {
 
 ipcMain.handle('get-logs', () => {
   return logEntries;
+});
+
+// Copying goes through the main process on purpose: the renderer would need a
+// secure-context clipboard permission, and the report has to be assembled from
+// the log file plus app/OS facts that only the main process holds.
+ipcMain.handle('copy-logs', () => {
+  try {
+    const report = buildCurrentLogReport();
+    clipboard.writeText(report);
+    return { success: true, length: report.length };
+  } catch (error) {
+    return { success: false, error: error.message };
+  }
+});
+
+ipcMain.handle('show-log-file', () => {
+  try {
+    const logFile = getLogFilePath();
+    if (!fs.existsSync(logFile)) {
+      // Nothing has been logged yet: reveal the folder rather than a dead path.
+      shell.openPath(app.getPath('userData'));
+      return { success: true, revealed: 'folder' };
+    }
+    shell.showItemInFolder(logFile);
+    return { success: true, revealed: 'file' };
+  } catch (error) {
+    return { success: false, error: error.message };
+  }
 });
 
 ipcMain.handle('clear-error', () => {

--- a/src/main/preload.js
+++ b/src/main/preload.js
@@ -32,6 +32,8 @@ contextBridge.exposeInMainWorld('api', {
   
   // Logs & errors
   getLogs: () => ipcRenderer.invoke('get-logs'),
+  copyLogs: () => ipcRenderer.invoke('copy-logs'),
+  showLogFile: () => ipcRenderer.invoke('show-log-file'),
   clearError: () => ipcRenderer.invoke('clear-error'),
   
   // Custom domains

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -291,6 +291,21 @@
         </button>
         <div class="logs-body" id="logsBody" style="display: none;">
           <div class="logs-list" id="logsList"></div>
+          <div class="logs-actions">
+            <button class="logs-action" id="logsCopy" title="Скопировать журнал вместе с версией приложения и системы">
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none">
+                <rect x="9" y="9" width="13" height="13" rx="2" stroke="currentColor" stroke-width="2"/>
+                <path d="M5 15H4a2 2 0 01-2-2V4a2 2 0 012-2h9a2 2 0 012 2v1" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+              </svg>
+              <span id="logsCopyLabel">Скопировать журнал</span>
+            </button>
+            <button class="logs-action logs-action-ghost" id="logsReveal" title="Открыть папку с файлом журнала">
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none">
+                <path d="M3 7a2 2 0 012-2h4l2 2h8a2 2 0 012 2v8a2 2 0 01-2 2H5a2 2 0 01-2-2V7z" stroke="currentColor" stroke-width="2" stroke-linejoin="round"/>
+              </svg>
+              <span>Файл</span>
+            </button>
+          </div>
         </div>
       </div>
 

--- a/src/renderer/renderer.js
+++ b/src/renderer/renderer.js
@@ -36,6 +36,9 @@ const logsChevron = document.getElementById('logsChevron');
 const logsBody = document.getElementById('logsBody');
 const logsList = document.getElementById('logsList');
 const logsCount = document.getElementById('logsCount');
+const logsCopy = document.getElementById('logsCopy');
+const logsCopyLabel = document.getElementById('logsCopyLabel');
+const logsReveal = document.getElementById('logsReveal');
 
 // Custom domains elements
 const domainsToggle = document.getElementById('domainsToggle');
@@ -172,6 +175,38 @@ function setupEventListeners() {
       logsList.scrollTop = logsList.scrollHeight;
     }
   });
+
+  logsCopy.addEventListener('click', copyLogs);
+  logsReveal.addEventListener('click', () => window.api.showLogFile());
+}
+
+// Restores the button label after the confirmation flash, so a second copy
+// still reads as a fresh action.
+let copyResetTimer = null;
+
+function flashCopyResult(label, stateClass) {
+  logsCopyLabel.textContent = label;
+  logsCopy.classList.remove('is-done', 'is-failed');
+  if (stateClass) logsCopy.classList.add(stateClass);
+
+  clearTimeout(copyResetTimer);
+  copyResetTimer = setTimeout(() => {
+    logsCopyLabel.textContent = 'Скопировать журнал';
+    logsCopy.classList.remove('is-done', 'is-failed');
+  }, 2000);
+}
+
+async function copyLogs() {
+  try {
+    const result = await window.api.copyLogs();
+    if (result && result.success) {
+      flashCopyResult('Скопировано', 'is-done');
+    } else {
+      flashCopyResult('Не удалось скопировать', 'is-failed');
+    }
+  } catch (e) {
+    flashCopyResult('Не удалось скопировать', 'is-failed');
+  }
 }
 
 async function loadSystemInfo() {

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -964,6 +964,12 @@ body {
   border-radius: var(--border-radius);
   border: 1px solid var(--border-color);
   overflow: hidden;
+  /* .main-content is a column flex container, so its children may shrink. Every
+     other card is limited by its content, but `overflow: hidden` sets this one's
+     automatic minimum size to zero — measured at the default 420x680 window the
+     card collapsed to 2px, which is why "разверните журнал" read as a card that
+     is not there. */
+  flex-shrink: 0;
 }
 
 .logs-header {

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -1345,3 +1345,58 @@ body {
 ::-webkit-scrollbar-thumb:hover {
   background: rgba(255, 255, 255, 0.15);
 }
+
+/* Log export — the only way a user can hand over diagnostics */
+.logs-actions {
+  display: flex;
+  gap: 8px;
+  padding: 10px 12px;
+  border-top: 1px solid var(--border-color);
+}
+
+.logs-action {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  flex: 1;
+  padding: 8px 10px;
+  border: 1px solid var(--border-color);
+  border-radius: var(--border-radius-sm);
+  background: var(--bg-hover);
+  color: var(--text-secondary);
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background var(--transition-fast), color var(--transition-fast), border-color var(--transition-fast);
+}
+
+.logs-action:hover {
+  background: #2a2a3a;
+  color: var(--text-primary);
+}
+
+.logs-action:active {
+  transform: translateY(1px);
+}
+
+.logs-action:focus-visible {
+  outline: 2px solid var(--accent-blue);
+  outline-offset: 2px;
+}
+
+.logs-action.is-done {
+  border-color: var(--accent-green);
+  color: var(--accent-green);
+}
+
+.logs-action.is-failed {
+  border-color: var(--accent-red);
+  color: var(--accent-red);
+}
+
+/* Secondary action: narrower, quieter — copying is the one that matters. */
+.logs-action-ghost {
+  flex: 0 0 auto;
+  background: none;
+}

--- a/test/log-report.test.js
+++ b/test/log-report.test.js
@@ -1,0 +1,158 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const test = require('node:test');
+
+const {
+  MAX_LOG_BYTES,
+  appendLogLine,
+  buildLogReport,
+  formatLogLine,
+  readLogTail
+} = require('../src/main/log-report');
+
+function tmpDir(t) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'unblock-pro-log-'));
+  t.after(() => fs.rmSync(dir, { recursive: true, force: true }));
+  return dir;
+}
+
+const AT = Date.UTC(2026, 7, 26, 13, 5, 11, 123);
+
+test('formats an entry with an absolute timestamp and level', () => {
+  const line = formatLogLine({ type: 'warning', message: 'проверка не пройдена', timestamp: AT });
+  assert.equal(line, '2026-08-26T13:05:11.123Z  warning  проверка не пройдена');
+});
+
+test('falls back to info when the level is missing', () => {
+  const line = formatLogLine({ message: 'без уровня', timestamp: AT });
+  assert.match(line, /  info  без уровня$/);
+});
+
+test('collapses newlines so one entry stays one line', () => {
+  const line = formatLogLine({ type: 'error', message: 'первая\nвторая', timestamp: AT });
+  assert.equal(line.split('\n').length, 1);
+  assert.match(line, /первая ⏎ вторая/);
+});
+
+test('appends entries to the file in order', (t) => {
+  const file = path.join(tmpDir(t), 'app.log');
+
+  appendLogLine(file, { type: 'info', message: 'первая', timestamp: AT });
+  appendLogLine(file, { type: 'info', message: 'вторая', timestamp: AT });
+
+  const lines = fs.readFileSync(file, 'utf8').trim().split('\n');
+  assert.equal(lines.length, 2);
+  assert.match(lines[0], /первая$/);
+  assert.match(lines[1], /вторая$/);
+});
+
+test('creates the directory when it does not exist yet', (t) => {
+  const file = path.join(tmpDir(t), 'nested', 'app.log');
+
+  appendLogLine(file, { type: 'info', message: 'первый запуск', timestamp: AT });
+
+  assert.ok(fs.existsSync(file));
+});
+
+test('rotates into .1 instead of growing without bound', (t) => {
+  const file = path.join(tmpDir(t), 'app.log');
+  const entry = (n) => ({ type: 'info', message: `строка ${n}`, timestamp: AT });
+
+  for (let i = 0; i < 40; i++) appendLogLine(file, entry(i), { maxBytes: 200 });
+
+  assert.ok(fs.existsSync(file + '.1'), 'предыдущий файл сохранён');
+  assert.ok(fs.statSync(file).size <= 200, 'текущий файл в пределах лимита');
+  const newest = fs.readFileSync(file, 'utf8');
+  assert.match(newest, /строка 39/, 'последняя запись не потеряна');
+});
+
+test('rotation keeps exactly one previous file', (t) => {
+  const file = path.join(tmpDir(t), 'app.log');
+  for (let i = 0; i < 200; i++) {
+    appendLogLine(file, { type: 'info', message: `строка ${i}`, timestamp: AT }, { maxBytes: 200 });
+  }
+
+  const dir = path.dirname(file);
+  assert.deepEqual(fs.readdirSync(dir).sort(), ['app.log', 'app.log.1']);
+});
+
+test('a write failure never throws at the caller', (t) => {
+  const dir = tmpDir(t);
+  // A directory where the log file should be: every write fails with EISDIR.
+  const file = path.join(dir, 'app.log');
+  fs.mkdirSync(file);
+
+  assert.doesNotThrow(() => appendLogLine(file, { type: 'info', message: 'тест', timestamp: AT }));
+});
+
+test('reads the rotated file and the current one as one history', (t) => {
+  const file = path.join(tmpDir(t), 'app.log');
+  fs.writeFileSync(file + '.1', 'старое\n');
+  fs.writeFileSync(file, 'новое\n');
+
+  assert.equal(readLogTail(file), 'старое\nновое\n');
+});
+
+test('reading a missing log returns an empty string', (t) => {
+  assert.equal(readLogTail(path.join(tmpDir(t), 'absent.log')), '');
+});
+
+test('report starts with the exact facts the issue form asks for', () => {
+  const report = buildLogReport({
+    fileText: '2026-08-26T13:05:11.123Z  info  подключение\n',
+    systemInfo: {
+      appVersion: '2.0.20',
+      osName: 'macOS',
+      osVersion: '15.7.7',
+      arch: 'arm64',
+      strategy: 'multi:disorder+tlsrec'
+    },
+    generatedAt: AT
+  });
+
+  assert.match(report, /UnblockPro 2\.0\.20/);
+  assert.match(report, /macOS 15\.7\.7 \(arm64\)/);
+  assert.match(report, /Стратегия: multi:disorder\+tlsrec/);
+  assert.match(report, /2026-08-26T13:05:11\.123Z  info  подключение/);
+});
+
+test('report says so plainly when no strategy is connected', () => {
+  const report = buildLogReport({
+    fileText: 'x\n',
+    systemInfo: { appVersion: '2.0.20', osName: 'Windows', osVersion: '11', arch: 'x64', strategy: null },
+    generatedAt: AT
+  });
+
+  assert.match(report, /Стратегия: не подключена/);
+});
+
+test('report falls back to in-memory entries when the file is unavailable', () => {
+  const report = buildLogReport({
+    fileText: '',
+    entries: [{ type: 'error', message: 'из памяти', timestamp: AT }],
+    systemInfo: { appVersion: '2.0.20', osName: 'macOS', osVersion: '15.7.7', arch: 'arm64' },
+    generatedAt: AT
+  });
+
+  assert.match(report, /из памяти/);
+});
+
+test('report is honest about an empty log rather than returning a bare header', () => {
+  const report = buildLogReport({
+    fileText: '',
+    entries: [],
+    systemInfo: { appVersion: '2.0.20', osName: 'macOS', osVersion: '15.7.7', arch: 'arm64' },
+    generatedAt: AT
+  });
+
+  assert.match(report, /Журнал пуст/);
+});
+
+test('the size cap is a real number of bytes', () => {
+  assert.equal(typeof MAX_LOG_BYTES, 'number');
+  assert.ok(MAX_LOG_BYTES > 0);
+});


### PR DESCRIPTION
Делает возможной просьбу «приложите журнал», которая сейчас невыполнима.

## Почему

В #46 и #56 авторы ответили, что не понимают, где взять журнал. Они правы:

- журнала на диске нет — это массив на 100 записей в памяти (`main.js`, `logEntries`);
- в карточке «Журнал» нет ни копирования, ни экспорта;
- **и самой карточки практически не видно**: `.main-content` — колоночный флекс, а у `.logs-card` стоит `overflow: hidden`, из-за чего её автоматический минимальный размер равен нулю и флекс сжимает карточку до 2 пикселей при штатном окне 420x680. Замерено в Electron на обеих ветках: `2px` на `main`, `215px` после фикса. Остальные карточки ограничены содержимым и не сжимаются — поэтому пропадал именно журнал.

Плюс объём: один прогон автоподбора проходит 52 macOS-стратегии через 68 точек логирования, так что начало прогона вытеснялось из кольцевого буфера ещё до того, как пользователь видел ошибку. Именно начало и нужно — там видно, какая проба отвергла какую стратегию.

## Что в PR

- `src/main/log-report.js` — новый модуль: формат строки, запись в файл с ротацией (1 МБ, одно предыдущее поколение), сборка отчёта. Все файловые ошибки проглатываются: отсутствие журнала — неудобство, падение подключения — нет.
- Журнал пишется в `userData/unblockpro.log` параллельно с буфером в памяти.
- IPC `copy-logs` и `show-log-file`; копирование идёт через main, потому что отчёт собирается из файла плюс версия приложения, ОС и активная стратегия.
- Кнопки «Скопировать журнал» и «Файл» в карточке журнала, с подтверждением на 2 секунды.
- `flex-shrink: 0` для карточки журнала.

В буфер попадает готовый к вставке в issue-форму текст:

```
UnblockPro 2.0.20
Windows 10.0.19045 (x64)
Стратегия: general (ALT12)
Сформировано: 2026-08-26T13:23:48.881Z
----------------------------------------------------
2026-08-26T13:23:47.546Z  info  Запуск подбора стратегии
2026-08-26T13:23:47.550Z  warning  Быстрая проверка: не прошли проверку — Discord API
2026-08-26T13:23:47.550Z  error  Все 52 стратегий не сработали
```

## Проверка

- 15 новых юнит-тестов на модуль (формат, ротация, чтение через ротацию, отчёт, молчаливое поведение при ошибке записи). Весь набор: 100/100.
- Живой прогон в Electron: настоящий `index.html` с настоящим `preload.js`, клик по кнопке, чтение системного буфера обмена — 10/10 проверок, включая содержимое отчёта и возврат подписи кнопки. `main.js` при этом не запускался, hosts и системный прокси не трогались.
- Скриншот карточки снят из Electron, кнопки в стиле приложения.

Не проверено: реальная сборка приложения и поведение на macOS — только Windows-окружение разработки.
