### PR TITLE
fix: проверять целостность движка перед каждым запуском с правами админа (#53)

### DIFF
--- a/src/main/main.js
+++ b/src/main/main.js
@@ -17,6 +17,11 @@ const {
 } = require('./system-files');
 const { copyFileResilient } = require('./safe-copy');
 const {
+  describeIntegrityFailure,
+  repairRuntimeFromReference,
+  verifyRuntimeAgainstReference
+} = require('./runtime-integrity');
+const {
   describeChildExit,
   hasExited,
   probeBinaryRuns,
@@ -179,6 +184,67 @@ function getBinaryPath() {
 function isWindowsBundleCurrent(platformDir = getResourcePath()) {
   if (process.platform !== 'win32') return true;
   return isFlowsealBundleCurrent(platformDir);
+}
+
+// The trusted copy of the Windows runtime: the one inside the installed
+// application. The installer is perMachine, so it sits under Program Files where
+// an unprivileged process cannot write — unlike the runtime directory in
+// %APPDATA% that the engine is actually launched from.
+function getRuntimeReferenceDir() {
+  if (process.platform !== 'win32' || !app.isPackaged) return null;
+
+  // The portable build unpacks its resources into a temp directory the user can
+  // write to, so the "reference" there is exactly as forgeable as the runtime it
+  // would be vouching for. Better to report that no check is possible than to
+  // compare a copy against itself and call it verified.
+  if (process.env.PORTABLE_EXECUTABLE_DIR) return null;
+
+  return path.join(process.resourcesPath, 'bin');
+}
+
+// Runs before every elevated launch. Returns { ok } or { ok: false, error }.
+async function ensureWindowsRuntimeIntegrity() {
+  const runtimeDir = getResourcePath();
+  const referenceDir = getRuntimeReferenceDir();
+
+  const result = verifyRuntimeAgainstReference(runtimeDir, referenceDir, FLOWSEAL_REQUIRED_WINDOWS_FILES);
+
+  if (!result.hasReference) {
+    // Portable build or a dev checkout: there is no admin-only copy to compare
+    // against. Say that plainly instead of implying the check passed.
+    sendLog({
+      type: 'warning',
+      message: 'Проверка целостности движка недоступна в этой сборке — эталонной копии нет'
+    });
+    return { ok: true };
+  }
+
+  if (result.ok) return { ok: true };
+
+  sendLog({
+    type: 'warning',
+    message: `Файлы движка не совпадают с эталоном (${describeIntegrityFailure(result)}) — восстанавливаю из приложения`
+  });
+
+  const { failed } = await repairRuntimeFromReference(
+    runtimeDir,
+    referenceDir,
+    FLOWSEAL_REQUIRED_WINDOWS_FILES,
+    { copyFile: (src, dest) => copyFileResilient(src, dest) }
+  );
+
+  const after = verifyRuntimeAgainstReference(runtimeDir, referenceDir, FLOWSEAL_REQUIRED_WINDOWS_FILES);
+  if (after.ok) {
+    sendLog({ type: 'success', message: 'Движок восстановлен из встроенной копии' });
+    return { ok: true };
+  }
+
+  // Refuse rather than run an unverified binary as administrator.
+  const detail = describeIntegrityFailure(after) || (failed[0] && failed[0].error) || 'причина неизвестна';
+  return {
+    ok: false,
+    error: `Файлы движка не совпадают с эталоном и восстановить их не удалось (${detail}). Подключение отменено — переустановите приложение.`
+  };
 }
 
 // ============= HOST LISTS & PATTERN FILES =============
@@ -2458,7 +2524,21 @@ async function runProxyStartAttempt() {
   }
   
   const totalStrategies = strategies.length;
-  
+
+  // Windows: the engine is about to be run with administrator rights out of a
+  // directory the user can write to. Check it against the copy shipped inside
+  // the installation before that happens, not only once at download time.
+  if (process.platform === 'win32') {
+    const integrity = await ensureWindowsRuntimeIntegrity();
+    if (!integrity.ok) {
+      lastError = integrity.error;
+      lastErrorCode = 'RUNTIME_INTEGRITY';
+      sendLog({ type: 'error', message: integrity.error });
+      sendStatus({ searching: false });
+      return { success: false, error: integrity.error };
+    }
+  }
+
   sendLog({ type: 'info', message: `Начинаю перебор ${totalStrategies} стратегий...` });
 
   // macOS: update hosts for Discord voice servers (all regions)

--- a/src/main/runtime-integrity.js
+++ b/src/main/runtime-integrity.js
@@ -1,0 +1,120 @@
+'use strict';
+
+// Checks the Windows bypass runtime against a trusted reference before it is
+// executed with administrator rights.
+//
+// The engine lives in %APPDATA%\unblock-pro\bin\win32 — a directory any
+// unprivileged process running as the same user can write to — and every
+// "Подключить" runs it elevated. Nothing on that path re-checked the files: the
+// SHA-256 was verified once, when the bundle was downloaded, and never again.
+// Replace winws.exe (or WinDivert64.sys) once and the replacement is executed as
+// administrator on every connect, however many UAC prompts the user confirms
+// (#53).
+//
+// The reference is the copy shipped inside the installed application. The
+// Windows installer is perMachine, so that directory lives under Program Files
+// and an unprivileged process cannot write to it — while the runtime directory
+// beside it can be rewritten by anyone. Comparing one against the other turns a
+// silent substitution into a repair.
+//
+// Deliberately not the whole answer: a portable build and a dev checkout have no
+// admin-only reference, and there `hasReference` is false. Say so rather than
+// implying a guarantee that is not there.
+
+const crypto = require('crypto');
+const fs = require('fs');
+const path = require('path');
+
+function sha256(file) {
+  return crypto.createHash('sha256').update(fs.readFileSync(file)).digest('hex');
+}
+
+function fileState(file) {
+  try {
+    if (!fs.statSync(file).isFile()) return { present: false, hash: null };
+    return { present: true, hash: sha256(file) };
+  } catch (e) {
+    return { present: false, hash: null };
+  }
+}
+
+// Compares each required file with the reference copy.
+//
+// Returns:
+//   hasReference — false when there is no trusted copy to compare against
+//   ok           — every file present and identical
+//   mismatched   — files that differ from the reference
+//   missing      — files absent from the runtime directory
+//   unreferenced — files the reference itself does not have (cannot be judged)
+function verifyRuntimeAgainstReference(runtimeDir, referenceDir, files) {
+  const result = { hasReference: false, ok: false, mismatched: [], missing: [], unreferenced: [] };
+
+  if (!runtimeDir || !referenceDir) return result;
+  try {
+    if (!fs.statSync(referenceDir).isDirectory()) return result;
+  } catch (e) {
+    return result;
+  }
+
+  for (const file of files) {
+    const reference = fileState(path.join(referenceDir, file));
+    if (!reference.present) {
+      result.unreferenced.push(file);
+      continue;
+    }
+    result.hasReference = true;
+
+    const runtime = fileState(path.join(runtimeDir, file));
+    if (!runtime.present) {
+      result.missing.push(file);
+    } else if (runtime.hash !== reference.hash) {
+      result.mismatched.push(file);
+    }
+  }
+
+  result.ok = result.hasReference && result.mismatched.length === 0 && result.missing.length === 0;
+  return result;
+}
+
+// Puts the reference copies back. Used when verification failed: the runtime
+// directory is a cache, so restoring it is always the right move — the file that
+// belongs there is the one shipped with the app.
+//
+// `copyFile` is injected so the caller can pass the resilient copy used for the
+// WinDivert driver, which can be locked while a previous engine is unloading.
+async function repairRuntimeFromReference(runtimeDir, referenceDir, files, { copyFile } = {}) {
+  const copy = copyFile || (async (src, dest) => { fs.copyFileSync(src, dest); });
+  const repaired = [];
+  const failed = [];
+
+  fs.mkdirSync(runtimeDir, { recursive: true });
+
+  for (const file of files) {
+    const source = path.join(referenceDir, file);
+    if (!fileState(source).present) continue;
+
+    try {
+      await copy(source, path.join(runtimeDir, file));
+      repaired.push(file);
+    } catch (e) {
+      failed.push({ file, error: e.message });
+    }
+  }
+
+  return { repaired, failed };
+}
+
+// One line for the log and the error message. Names the files, because "проверка
+// целостности не пройдена" without them is unactionable.
+function describeIntegrityFailure(result) {
+  const parts = [];
+  if (result.mismatched.length > 0) parts.push(`изменены: ${result.mismatched.join(', ')}`);
+  if (result.missing.length > 0) parts.push(`отсутствуют: ${result.missing.join(', ')}`);
+  return parts.join('; ');
+}
+
+module.exports = {
+  describeIntegrityFailure,
+  repairRuntimeFromReference,
+  verifyRuntimeAgainstReference
+};

--- a/src/renderer/renderer.js
+++ b/src/renderer/renderer.js
@@ -74,7 +74,8 @@ const ERROR_TITLES = {
   'PERMISSION_DENIED': 'Нет прав доступа',
   'PORT_IN_USE': 'Порт занят',
   'NETWORK_UNAVAILABLE': 'Нет сети',
-  'ALREADY_RUNNING': 'Уже подключено'
+  'ALREADY_RUNNING': 'Уже подключено',
+  'RUNTIME_INTEGRITY': 'Файлы движка изменены'
 };
 
 // Initialize

--- a/test/runtime-integrity.test.js
+++ b/test/runtime-integrity.test.js
@@ -1,0 +1,156 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const test = require('node:test');
+
+const {
+  describeIntegrityFailure,
+  repairRuntimeFromReference,
+  verifyRuntimeAgainstReference
+} = require('../src/main/runtime-integrity');
+
+const FILES = ['winws.exe', 'WinDivert64.sys', 'WinDivert.dll'];
+
+function dirs(t) {
+  const base = fs.mkdtempSync(path.join(os.tmpdir(), 'unblock-integrity-'));
+  t.after(() => fs.rmSync(base, { recursive: true, force: true }));
+
+  const reference = path.join(base, 'reference');
+  const runtime = path.join(base, 'runtime');
+  fs.mkdirSync(reference, { recursive: true });
+  fs.mkdirSync(runtime, { recursive: true });
+
+  for (const file of FILES) {
+    fs.writeFileSync(path.join(reference, file), `genuine ${file}`);
+    fs.writeFileSync(path.join(runtime, file), `genuine ${file}`);
+  }
+
+  return { base, reference, runtime };
+}
+
+test('an untouched runtime passes', (t) => {
+  const { runtime, reference } = dirs(t);
+
+  const result = verifyRuntimeAgainstReference(runtime, reference, FILES);
+
+  assert.equal(result.ok, true);
+  assert.equal(result.hasReference, true);
+  assert.deepEqual(result.mismatched, []);
+});
+
+test('a swapped engine is caught', (t) => {
+  const { runtime, reference } = dirs(t);
+  fs.writeFileSync(path.join(runtime, 'winws.exe'), 'malicious payload');
+
+  const result = verifyRuntimeAgainstReference(runtime, reference, FILES);
+
+  assert.equal(result.ok, false);
+  assert.deepEqual(result.mismatched, ['winws.exe']);
+});
+
+test('a swapped driver is caught too — not just the executable', (t) => {
+  const { runtime, reference } = dirs(t);
+  fs.writeFileSync(path.join(runtime, 'WinDivert64.sys'), 'rootkit');
+
+  const result = verifyRuntimeAgainstReference(runtime, reference, FILES);
+
+  assert.deepEqual(result.mismatched, ['WinDivert64.sys']);
+});
+
+test('a file of the same size but different content is caught', (t) => {
+  const { runtime, reference } = dirs(t);
+  const genuine = fs.readFileSync(path.join(reference, 'winws.exe'), 'utf8');
+  const forged = 'g' + 'e'.repeat(genuine.length - 1);
+  assert.equal(forged.length, genuine.length);
+  fs.writeFileSync(path.join(runtime, 'winws.exe'), forged);
+
+  assert.deepEqual(verifyRuntimeAgainstReference(runtime, reference, FILES).mismatched, ['winws.exe']);
+});
+
+test('a missing file is reported separately from a modified one', (t) => {
+  const { runtime, reference } = dirs(t);
+  fs.unlinkSync(path.join(runtime, 'WinDivert.dll'));
+
+  const result = verifyRuntimeAgainstReference(runtime, reference, FILES);
+
+  assert.deepEqual(result.missing, ['WinDivert.dll']);
+  assert.deepEqual(result.mismatched, []);
+  assert.equal(result.ok, false);
+});
+
+test('without a reference the check claims nothing', (t) => {
+  const { runtime, base } = dirs(t);
+
+  const result = verifyRuntimeAgainstReference(runtime, path.join(base, 'absent'), FILES);
+
+  assert.equal(result.hasReference, false);
+  assert.equal(result.ok, false, 'нет эталона — нет и подтверждения целостности');
+});
+
+test('a file the reference does not carry cannot be judged', (t) => {
+  const { runtime, reference } = dirs(t);
+  fs.writeFileSync(path.join(runtime, 'extra.bin'), 'whatever');
+
+  const result = verifyRuntimeAgainstReference(runtime, reference, [...FILES, 'extra.bin']);
+
+  assert.deepEqual(result.unreferenced, ['extra.bin']);
+  assert.equal(result.ok, true, 'остальные файлы всё ещё проверены');
+});
+
+test('a directory in place of a file is not mistaken for one', (t) => {
+  const { runtime, reference } = dirs(t);
+  fs.unlinkSync(path.join(runtime, 'winws.exe'));
+  fs.mkdirSync(path.join(runtime, 'winws.exe'));
+
+  assert.deepEqual(verifyRuntimeAgainstReference(runtime, reference, FILES).missing, ['winws.exe']);
+});
+
+test('repair restores the reference copies and verification then passes', async (t) => {
+  const { runtime, reference } = dirs(t);
+  fs.writeFileSync(path.join(runtime, 'winws.exe'), 'malicious payload');
+  fs.unlinkSync(path.join(runtime, 'WinDivert.dll'));
+
+  const { repaired, failed } = await repairRuntimeFromReference(runtime, reference, FILES);
+
+  assert.deepEqual(failed, []);
+  assert.deepEqual(repaired.sort(), FILES.slice().sort());
+  assert.equal(verifyRuntimeAgainstReference(runtime, reference, FILES).ok, true);
+  assert.equal(fs.readFileSync(path.join(runtime, 'winws.exe'), 'utf8'), 'genuine winws.exe');
+});
+
+test('repair recreates the runtime directory when it is gone', async (t) => {
+  const { runtime, reference } = dirs(t);
+  fs.rmSync(runtime, { recursive: true, force: true });
+
+  await repairRuntimeFromReference(runtime, reference, FILES);
+
+  assert.equal(verifyRuntimeAgainstReference(runtime, reference, FILES).ok, true);
+});
+
+test('a locked file is reported instead of silently skipped', async (t) => {
+  const { runtime, reference } = dirs(t);
+  const copyFile = async (src, dest) => {
+    if (dest.endsWith('WinDivert64.sys')) {
+      const err = new Error('EBUSY: resource busy or locked');
+      err.code = 'EBUSY';
+      throw err;
+    }
+    fs.copyFileSync(src, dest);
+  };
+
+  const { repaired, failed } = await repairRuntimeFromReference(runtime, reference, FILES, { copyFile });
+
+  assert.equal(failed.length, 1);
+  assert.equal(failed[0].file, 'WinDivert64.sys');
+  assert.ok(repaired.includes('winws.exe'));
+});
+
+test('the failure description names the files, so the message is actionable', () => {
+  const text = describeIntegrityFailure({ mismatched: ['winws.exe'], missing: ['WinDivert.dll'] });
+
+  assert.match(text, /изменены: winws\.exe/);
+  assert.match(text, /отсутствуют: WinDivert\.dll/);
+});


### PR DESCRIPTION
Закрывает #53 по варианту 1.

## Что было

`winws.exe` запускается с правами администратора из `%APPDATA%\unblock-pro\bin\win32` — каталога, в который пишет любой непривилегированный процесс от имени того же пользователя. На пути запуска проверки не было: SHA-256 сверялась **один раз при скачивании** и больше никогда, а `isFlowsealBundleCurrent()` смотрит только на наличие файлов и текстовый маркер версии.

Подменить `winws.exe` или `WinDivert64.sys` достаточно один раз — дальше подмена молча исполняется с правами администратора при каждом нажатии «Подключить», сколько бы раз пользователь ни подтверждал UAC.

## Что стало

Перед подключением каждый файл рантайма сверяется по SHA-256 с копией, лежащей **внутри установленного приложения**. Установщик `perMachine`, поэтому эта копия находится в `Program Files`, куда непривилегированный процесс писать не может — в отличие от рабочего каталога рядом с ней. Это и делает сравнение осмысленным: подмена возможна ровно там, где эталона нет.

Несовпадение не роняет подключение, а чинится: файлы восстанавливаются из встроенной копии (тем же устойчивым к блокировкам копированием, что и при установке — `WinDivert64.sys` может быть залочен выгружающимся драйвером), после чего проверка повторяется. И только если восстановить не удалось, подключение отменяется с внятным сообщением, вместо запуска непроверенного бинарника от администратора.

## Где проверка невозможна — и это сказано вслух

- **portable-сборка**: ресурсы распаковываются во временный каталог, доступный пользователю на запись, то есть «эталон» там подделывается ровно так же, как и рантайм. Определяется по `PORTABLE_EXECUTABLE_DIR`, эталон считается отсутствующим.
- **запуск из исходников**: встроенной копии нет.

В обоих случаях в журнал пишется, что проверка недоступна. Сравнивать копию с самой собой и называть это проверкой — хуже, чем не проверять.

## Что этот PR НЕ закрывает

Вариант 2 из иссью — держать рантайм в каталоге, доступном на запись только администратору, — остаётся более надёжным решением и здесь не сделан. Текущий фикс превращает подмену в самовосстановление и убирает тихое исполнение подменённого файла, но сам каталог по-прежнему доступен на запись, и portable-сборка не защищена вовсе.

## Проверка

- **97/97 юнит-тестов** (85 на `main` плюс 12 новых): подмена движка, подмена драйвера, подмена с сохранением размера файла, пропавший файл отдельно от изменённого, каталог вместо файла, отсутствие эталона, восстановление, восстановление при удалённом каталоге, залоченный файл в отчёте об ошибках, формулировка сообщения.
- **Живой прогон на настоящих файлах** — 11/11, включая связку с `copyFileResilient`, который приложение подставляет как копирование. Реалистичные размеры (winws.exe 1.5 МБ, cygwin1.dll 3 МБ): **проверка занимает 30 мс** на все 10 файлов, то есть на время подключения не влияет.

## Что НЕ проверено

Сборка и установка не запускались: то, что `resources/bin` в установленном приложении действительно недоступен на запись обычному пользователю, следует из `perMachine` в конфиге NSIS, но вживую ACL не проверялся. Реальный сценарий с UAC не гонялся.
